### PR TITLE
Correct typo in thingsboard-gateway.service

### DIFF
--- a/setup_files/thingsboard-gateway.service
+++ b/setup_files/thingsboard-gateway.service
@@ -2,8 +2,7 @@
 Description=ThingsBoard Gateway
 
 [Service]
-ExecStart=/usr/bin/python
-/home/pi/thingsboard-gateway/thingsboard-gateway/thingsboard_gateway/tb_gateway.py
+ExecStart=/usr/bin/python /home/pi/thingsboard-gateway/thingsboard-gateway/thingsboard_gateway/tb_gateway.py
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
A newline typo broke the service file. Removing it fixes the file.