### PR TITLE
Documentation and Funcationality Improvements for ZigBee and VarIoT Gateway Installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__
 /thingsboard_gateway/config/
 /venv/
 /docs/_build/*
+.vscode/*

--- a/docs/installation/tb-gateway.rst
+++ b/docs/installation/tb-gateway.rst
@@ -23,7 +23,7 @@ Install ThingsBoard Gateway
 #. In order to run your gateway from the source, copy :code:`thingsboard-gateway.service` to the :code:`/etc/systemd/system` directory
    
    * Move to the directory the service file will live in: :code:`cd /etc/systemd/system`
-   * Copy the service file to the current directory: :code:`cp ~/setup_files/thingsboard-gateway.service .` <-- the period here is important
+   * Copy the service files to the current directory: :code:`cp ~/setup_files/*.service .` <-- the period here is important
 #. Notify the system that daemons were changed: :code:`sudo systemctl daemon-reload`
 
 Create Gateway Device
@@ -48,6 +48,7 @@ Configure ThingsBoard Gateway
 Run ThingsBoard Gateway
 -----------------------
 #. Start the ThingsBoard service: :code:`sudo service thingsboard-gateway start`
+#. Enable the Thingsboard service on start-up: :code:`sudo systemctl enable thingsboard-gateway.service`
 #. Check the service status: :code:`sudo service thingsboard-gateway status` (Press q to return to the prompt)
    
    The ouput should look like the following:

--- a/docs/protocols/zigbee.rst
+++ b/docs/protocols/zigbee.rst
@@ -30,6 +30,8 @@ coordinator firmware. This should be done from your laptop/desktop/ a system sep
 
 #. Click *Load image* to upload the firmware
 
+**Note:** If at any point UniFlash tells you to update the firmware, do so. If you have already erased the flash, do it again. If you encounter an error after updating the firmware, unplug and re-plug the board, then erase again.
+
 Software Setup
 --------------
 
@@ -38,5 +40,13 @@ Software Setup
 #. Follow the instructions as-described in the `Linux Zigbee2MQTT Setup Instructions <https://www.zigbee2mqtt.io/guide/installation/01_linux.html>`_.
 
    * Be sure to follow the *(Optional) Running as a daemon with systemctl* instructions as well so that Zigbee2MQTT starts up when the gateway does.
+   * Do not do the optional step involving generating a network key
+   * To easily check if `/dev/ACM0` exists, `cd ~/thingsboard-gateway/setup_files` and `./walk.sh`. This script will print out all device paths of connected devices.
+   * If `/dev/ACM0` does not exist after plugging in, reboot the gateway with the board still plugged in.
+   * If there are other ZigBee networks nearby, you will need to configure your network to operate on a different channel. This is most easily done by checking the ZigBee configuration file `<zigbee installation directory>/data/configuration.yaml` of the other ZigBee networks if possible. The alternative is trial and error. Start with channel 15 and work your way up (start with 15 to try to avoid 2.4Ghz Wi-Fi overlaps). Append the following to your `/opt/zigbee2mqtt/data/configuration.yaml` to change the channel:
+      ::
+         
+         advanced:
+            channel: 15
 
 #. Once the above is complete, the next step is to :ref:`add the IP address for the gateway to Flask<add-gateway-ip-address>`

--- a/setup_files/bluetooth-kill.sh
+++ b/setup_files/bluetooth-kill.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+for device in $(hcitool con | grep -o "[[:xdigit:]:]\{8,17\}"); do
+    bluetoothctl disconnect $device
+done

--- a/setup_files/thingsboard-gateway.service
+++ b/setup_files/thingsboard-gateway.service
@@ -1,8 +1,10 @@
 [Unit]
 Description=ThingsBoard Gateway
+After=network-online.target wait-for-dns.service
+Wants=network-online.target wait-for-dns.service
 
 [Service]
-ExecStart=/usr/bin/python /home/pi/thingsboard-gateway/thingsboard-gateway/thingsboard_gateway/tb_gateway.py
+ExecStart=/usr/bin/python3 /home/pi/thingsboard-gateway/thingsboard-gateway/thingsboard_gateway/tb_gateway.py
 
 [Install]
 WantedBy=multi-user.target

--- a/setup_files/thingsboard-gateway.service
+++ b/setup_files/thingsboard-gateway.service
@@ -5,6 +5,7 @@ Wants=network-online.target wait-for-dns.service
 
 [Service]
 ExecStart=/usr/bin/python3 /home/pi/thingsboard-gateway/thingsboard-gateway/thingsboard_gateway/tb_gateway.py
+ExecStopPost=/home/pi/thingsboard-gateway/setup_files/bluetooth-kill.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/setup_files/wait-for-dns.service
+++ b/setup_files/wait-for-dns.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Wait for DNS
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'while ! host variot.ece.drexel.edu; do sleep 1; done'

--- a/setup_files/walk.sh
+++ b/setup_files/walk.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do
+    (
+        syspath="${sysdevpath%/dev}"
+        devname="$(udevadm info -q name -p $syspath)"
+        [[ "$devname" == "bus/"* ]] && exit
+        eval "$(udevadm info -q property --export -p $syspath)"
+        [[ -z "$ID_SERIAL" ]] && exit
+        echo "/dev/$devname - $ID_SERIAL"
+    )
+done


### PR DESCRIPTION
### Documentation Changes For ZigBee Gateway Installation:
- Clarify documentation
- Document errors that have been encountered and possible solutions
- Create walk.sh script to ease finding the ZigBee Gateway device path

### Documentation Changes For VarIoT Gateway Installation:
- Enable thingsboard-gateway.service on startup
- Add wait-for-dns.service to setup_files

### Functionality Changes for VarIoT Gateway:
- Modify the thingsboard-gateway.service file to call bluetooth-kill.sh on stop
- Make bluetooth-kill.sh to disconnect all bluetooth devices so they can reconnect later
(this is only necessary because of a bug in thingsboard)

(also update .gitignore for VS Code)